### PR TITLE
Add version of mmcedrv with FHI integrated: mmcefhi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,16 @@ all:
 	$(MAKE) -C mmceman
 	$(MAKE) -C mmcedrv
 	$(MAKE) -C mmceigr
+	$(MAKE) -C mmcefhi
 
 clean:
 	$(MAKE) -C mmceman clean
 	$(MAKE) -C mmcedrv clean
 	$(MAKE) -C mmceigr clean
+	$(MAKE) -C mmcefhi clean
+
+install:
+	cp mmceman/irx/mmceman.irx $(PS2SDK)/iop/irx/
+	cp mmcedrv/irx/mmcedrv.irx $(PS2SDK)/iop/irx/
+	cp mmceigr/irx/mmceigr.irx $(PS2SDK)/iop/irx/
+	cp mmcefhi/irx/mmcefhi.irx $(PS2SDK)/iop/irx/

--- a/mmcefhi/Makefile
+++ b/mmcefhi/Makefile
@@ -1,0 +1,23 @@
+IOP_SRC_DIR ?= ../mmceman/src/
+IOP_INC_DIR ?= ../mmceman/include/
+
+$(info -- MMCEFHI)
+#Build minimal MMCE driver for use in-game in neutrino
+IOP_BIN = irx/mmcefhi.irx
+IOP_OBJS = ioplib.o sio2man_hook.o mmce_sio2.o exports.o imports.o mmcedrv.o mmce_fhi.o
+IOP_CFLAGS += -DMMCEDRV -DFHI -I../../../apps/neutrino/iop/common/
+
+all: $(IOP_BIN)
+
+clean:
+	rm -f -r $(IOP_OBJS) $(IOP_BIN)
+
+ifeq ($(DEBUG), 1)
+  $(info -- MMCEMAN debug enabled)
+  IOP_CFLAGS += -DDEBUG
+  IOP_CFLAGS += -DDEBUG=1
+endif
+
+include $(PS2SDK)/Defs.make
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.iopglobal

--- a/mmceman/src/exports.tab
+++ b/mmceman/src/exports.tab
@@ -8,6 +8,8 @@ int _dummy(void) {
     return 1;
 }
 
+#ifndef FHI
+// Exports needed by OPL
 DECLARE_EXPORT_TABLE(mmcedrv, 1, 1)
     DECLARE_EXPORT(_retonly)
     DECLARE_EXPORT(_retonly)
@@ -20,3 +22,15 @@ DECLARE_EXPORT_TABLE(mmcedrv, 1, 1)
     DECLARE_EXPORT(mmcedrv_write)
     DECLARE_EXPORT(mmcedrv_lseek)
 END_EXPORT_TABLE
+#else
+// Exports needed by neutrino
+DECLARE_EXPORT_TABLE(fhi, 1, 1)
+    DECLARE_EXPORT(_retonly)
+    DECLARE_EXPORT(_retonly)
+    DECLARE_EXPORT(_ret0)
+    DECLARE_EXPORT(_retonly)
+    DECLARE_EXPORT(fhi_size)
+    DECLARE_EXPORT(fhi_read)
+    DECLARE_EXPORT(fhi_write)
+END_EXPORT_TABLE
+#endif

--- a/mmceman/src/imports.lst
+++ b/mmceman/src/imports.lst
@@ -38,6 +38,7 @@ sysclib_IMPORTS_end
 thbase_IMPORTS_start
 I_SetAlarm
 I_CancelAlarm
+I_DelayThread
 thbase_IMPORTS_end
 
 thevent_IMPORTS_start

--- a/mmceman/src/imports.lst
+++ b/mmceman/src/imports.lst
@@ -38,7 +38,6 @@ sysclib_IMPORTS_end
 thbase_IMPORTS_start
 I_SetAlarm
 I_CancelAlarm
-I_DelayThread
 thbase_IMPORTS_end
 
 thevent_IMPORTS_start

--- a/mmceman/src/mmce_fhi.c
+++ b/mmceman/src/mmce_fhi.c
@@ -10,8 +10,6 @@ struct fhi_fileid fhi = {MODULE_SETTINGS_MAGIC};
 
 static int mmce_io_sema;
 
-extern void mmcedrv_config_set(int setting, int value);
-extern s64 mmcedrv_get_size(int fd);
 extern int mmcedrv_lseek(int fd, int offset, int whence);
 extern int mmcedrv_read_sector(int fd, u32 sector, u32 count, void *buffer);
 extern int mmcedrv_read(int fd, int size, void *ptr);
@@ -20,34 +18,14 @@ extern int mmcedrv_write(int fd, int size, const void *ptr);
 
 //---------------------------------------------------------------------------
 // FHI export #4
-//TEMP: used as an init func
 u32 fhi_size(int file_handle)
 {
-    uint64_t iso_size;
+    if (file_handle < 0 || file_handle >= FHI_MAX_FILES)
+        return 0;
 
-    //Set port, fd's, and settings
-    DPRINTF("Port: %i\n", fhi.devNr + 2);
-    //DPRINTF("ISO fd: %i\n", fhi.iso_fd);
-    //DPRINTF("VMC fd: %i\n", fhi.vmc_fd);
-    //DPRINTF("Ack wait cycles: %i\n", fhi.ack_wait_cycles);
-    //DPRINTF("Use alarms: %i\n", fhi.use_alarms);
+    DPRINTF("%s(%d)\n", __func__, file_handle);
 
-    mmcedrv_config_set(MMCEDRV_SETTING_PORT, fhi.devNr + 2);
-    mmcedrv_config_set(MMCEDRV_SETTING_ACK_WAIT_CYCLES, 0);
-    mmcedrv_config_set(MMCEDRV_SETTING_USE_ALARMS, 0);
-
-    DPRINTF("Waiting for device...\n");
-
-    while (1) {
-        iso_size = mmcedrv_get_size(fhi.file[file_handle].id);
-        if (iso_size > 0)
-            break;
-        DelayThread(100 * 1000); // 100ms
-    }
-
-    SignalSema(mmce_io_sema);
-
-    return iso_size;
+    return fhi.file[file_handle].size / 512;
 }
 
 //---------------------------------------------------------------------------

--- a/mmceman/src/mmce_fhi.c
+++ b/mmceman/src/mmce_fhi.c
@@ -10,7 +10,7 @@ struct fhi_fileid fhi = {MODULE_SETTINGS_MAGIC};
 
 static int mmce_io_sema;
 
-extern int mmcedrv_lseek(int fd, int offset, int whence);
+extern s64 mmcedrv_lseek64(int fd, s64 offset, int whence);
 extern int mmcedrv_read_sector(int fd, u32 sector, u32 count, void *buffer);
 extern int mmcedrv_read(int fd, int size, void *ptr);
 extern int mmcedrv_write(int fd, int size, const void *ptr);
@@ -58,7 +58,7 @@ int fhi_read(int file_handle, void *buffer, unsigned int sector_start, unsigned 
 
     //Other files (VMC/ATA/...), use lseek + read
     } else {
-        mmcedrv_lseek(fhi.file[file_handle].id, sector_start * 512, 0);
+        mmcedrv_lseek64(fhi.file[file_handle].id, (s64)sector_start * 512, 0);
         res = mmcedrv_read(fhi.file[file_handle].id, sector_count * 512, buffer);
 
         if (res == sector_count * 512)
@@ -92,7 +92,7 @@ int fhi_write(int file_handle, const void *buffer, unsigned int sector_start, un
     DPRINTF("%s(%i, %u, 0x%p, %u)\n", __func__, file_handle, (unsigned int)sector_start, buffer, sector_count);
 
     WaitSema(mmce_io_sema);
-    mmcedrv_lseek(fhi.file[file_handle].id, sector_start * 512, 0);
+    mmcedrv_lseek64(fhi.file[file_handle].id, (s64)sector_start * 512, 0);
     res = mmcedrv_write(fhi.file[file_handle].id, sector_count * 512, buffer);
     SignalSema(mmce_io_sema);
 

--- a/mmceman/src/mmcedrv.c
+++ b/mmceman/src/mmcedrv.c
@@ -22,9 +22,12 @@ IRX_ID("mmcedrv", MAJOR, MINOR);
 #ifndef FHI
 extern struct irx_export_table _exp_mmcedrv;
 #else
+#include "fhi_fileid.h"
 extern struct irx_export_table _exp_fhi;
+extern struct fhi_fileid fhi;
 #endif
 
+#ifndef FHI
 s64 mmcedrv_get_size(int fd)
 {
     int res;
@@ -76,6 +79,7 @@ s64 mmcedrv_get_size(int fd)
 
     return position;
 }
+#endif
 
 int mmcedrv_read_sector(int fd, u32 sector, u32 count, void *buffer)
 {
@@ -348,6 +352,7 @@ int mmcedrv_lseek(int fd, int offset, int whence)
     return position;
 }
 
+#ifndef FHI
 //For OPL, called through CDVDMAN Device
 void mmcedrv_config_set(int setting, int value)
 {
@@ -373,6 +378,7 @@ void mmcedrv_config_set(int setting, int value)
         break;
     }
 }
+#endif
 
 int __start(int argc, char *argv[])
 {
@@ -398,6 +404,10 @@ int __start(int argc, char *argv[])
         DPRINTF("ERROR: library already registered\n");
         return MODULE_NO_RESIDENT_END;
     }
+
+    mmce_sio2_set_port(fhi.devNr + 2);
+    //mmce_sio2_update_ack_wait_cycles(0);
+    //mmce_sio2_set_use_alarm(0);
 #endif
 
     iop_library_t * lib_modload = ioplib_getByName("modload");

--- a/mmceman/src/mmcedrv.c
+++ b/mmceman/src/mmcedrv.c
@@ -307,6 +307,7 @@ int mmcedrv_write(int fd, int size, void *ptr)
     return bytes_written;
 }
 
+#ifndef FHI
 int mmcedrv_lseek(int fd, int offset, int whence)
 {
     int res;
@@ -351,6 +352,58 @@ int mmcedrv_lseek(int fd, int offset, int whence)
 
     return position;
 }
+#else
+s64 mmcedrv_lseek64(int fd, s64 offset, int whence)
+{
+    int res;
+    s64 position = -1;
+
+    DPRINTF("%s: fd: %i, offset: %i, whence: %i\n", __func__, fd, offset, whence);
+
+    u8 wrbuf[0xd];
+    u8 rdbuf[0x16];
+
+    wrbuf[0x0] = MMCE_ID;                       //Identifier
+    wrbuf[0x1] = MMCE_CMD_FS_LSEEK64;           //Command
+    wrbuf[0x2] = MMCE_RESERVED;                 //Reserved
+    wrbuf[0x3] = fd;                            //File descriptor
+    wrbuf[0x4] = (offset & 0xFF00000000000000) >> 56;   //Offset
+    wrbuf[0x5] = (offset & 0x00FF000000000000) >> 48;
+    wrbuf[0x6] = (offset & 0x0000FF0000000000) >> 40;
+    wrbuf[0x7] = (offset & 0x000000FF00000000) >> 32;
+    wrbuf[0x8] = (offset & 0x00000000FF000000) >> 24;
+    wrbuf[0x9] = (offset & 0x0000000000FF0000) >> 16;
+    wrbuf[0xa] = (offset & 0x000000000000FF00) >> 8;
+    wrbuf[0xb] = (offset & 0x00000000000000FF);
+    wrbuf[0xc] = (u8)(whence);  //Whence
+
+    //Packet #1: Command, file descriptor, offset, and whence
+    mmce_sio2_lock();
+    res = mmce_sio2_tx_rx_pio(0xd, 0x16, wrbuf, rdbuf, &timeout_1s);
+    mmce_sio2_unlock();
+
+    if (res == -1) {
+        DPRINTF("%s ERROR: P1 - Timedout waiting for /ACK\n", __func__);
+        return -1;
+    }
+
+    if (rdbuf[0x1] != MMCE_REPLY_CONST) {
+        DPRINTF("%s ERROR: Invalid response from card. Got 0x%x, Expected 0x%x\n", __func__, rdbuf[0x1], MMCE_REPLY_CONST);
+        return -1;
+    }
+
+    position  = (s64)rdbuf[0xd] << 56;
+    position |= (s64)rdbuf[0xe] << 48;
+    position |= (s64)rdbuf[0xf] << 40;
+    position |= (s64)rdbuf[0x10] << 32;
+    position |= (s64)rdbuf[0x11] << 24;
+    position |= (s64)rdbuf[0x12] << 16;
+    position |= (s64)rdbuf[0x13] << 8;
+    position |= (s64)rdbuf[0x14];
+
+    return position;
+}
+#endif
 
 #ifndef FHI
 //For OPL, called through CDVDMAN Device

--- a/mmceman/src/mmcedrv.c
+++ b/mmceman/src/mmcedrv.c
@@ -406,8 +406,8 @@ int __start(int argc, char *argv[])
     }
 
     mmce_sio2_set_port(fhi.devNr + 2);
-    //mmce_sio2_update_ack_wait_cycles(0);
-    //mmce_sio2_set_use_alarm(0);
+    mmce_sio2_update_ack_wait_cycles(0);
+    mmce_sio2_set_use_alarm(0);
 #endif
 
     iop_library_t * lib_modload = ioplib_getByName("modload");


### PR DESCRIPTION
Just wanted to share with you my current approach to using mmcedrv in neutrino.
Basically I've merged fhi_mmce and mmcedrv into 1 driver. This reduced the needed modules by 1, and also reduces the size.

Current issues:
- I don't know how to share the "interface" header between neutrino and this mmceman repository. The makefile currently adds `-I../../../apps/neutrino/iop/common/` but this obviously only works for me.
- file handles still require an mmce special fileXioIoctl2 call in neutrino. This has to be solved.
- card timing and alarm enable is currently not configurable.

Please let me know what you think of this approach and if you have ideas on how to solve the above issues.