### PR TITLE
Changes to mmceman for ps2sdk sio2man client updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,7 @@ on:
       - '*'
     tags:
       - v*
+  pull_request:
   repository_dispatch:
     types: [run_build]
   workflow_dispatch: {}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Before launching MMCEDRV, all files must be opened by MMCEMAN. Their file descri
 # Known Issues:
 
 ### SIO2MAN Version Compatibility:
-The SIO2MAN hook has not yet been updated to support SIO2MAN version 2.7 or newer (SDK 3.0.3). As a result, titles built using SDK 3.0.3 or later are currently unsupported. This limitation also applies to MX4SIO.
+The SIO2MAN hook only supports the SIO2MAN implementation from ps2sdk (which supports all known interfaces from 1.1 to 2.7), or SIO2MAN version 2.7 or newer (SCE SDK 3.0.3). This limitation also applies to MX4SIO.
 
 ### Deadlock Issues:
 During early testing, two games were identified to have deadlock issues caused by how the IOP handles semaphores and threads:

--- a/mmceman/include/ioplib.h
+++ b/mmceman/include/ioplib.h
@@ -3,7 +3,7 @@
 #  ____|   |    ____|   |        | |____|
 # |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
 #-----------------------------------------------------------------------
-# Copyright 2001-2009, ps2dev - http://www.ps2dev.org
+# Copyright ps2dev - http://www.ps2dev.org
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 #
@@ -14,25 +14,27 @@
 #ifndef IOPLIB_H
 #define IOPLIB_H
 
+
 #include <loadcore.h>
 
-/** @brief get library object of any IRX Module
- * @param name name of the module to search for
- * @return NULL on error.
+typedef int (*ioplib_libiterate_cb_t)(iop_library_t *lib, void *userdata);
+
+/** @brief Iterate for each library found by name
+ * @param name Name of the module to search for
+ * @param callback Callback called when the library name matches
+ * @param userdata User data to pass to the callback
+ * @return count of items found
  */
-iop_library_t *ioplib_getByName(const char *name);
-unsigned int ioplib_getTableSize(iop_library_t *lib);
-
-
-/** @brief hook an IRX Module exported function
+extern int ioplib_iterateByName(const char *name, ioplib_libiterate_cb_t cb, void *userdata);
+extern unsigned int ioplib_getTableSize(iop_library_t *lib);
+/** @brief Hook all IRX module exported functions that matches the specified entry.
  * @param lib Library object of the module to hook
  * @param entry Export number to be hooked
  * @param func Hook function
  * @return on error: NULL | on success: original function pointer
  */
-void *ioplib_hookExportEntry(iop_library_t *lib, unsigned int entry, void *func);
-
-void ioplib_relinkExports(iop_library_t *lib);
+extern void *ioplib_hookSameExportEntries(iop_library_t *lib, unsigned int entry, void *func);
+extern void ioplib_relinkExports(iop_library_t *lib);
 
 
 #endif

--- a/mmceman/include/sio2man_hook.h
+++ b/mmceman/include/sio2man_hook.h
@@ -1,23 +1,33 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+# taken from MX4SIO driver for simplicity.
+# all credits go to maximus32
+*/
+
 #ifndef SIO2MAN_HOOK_H
 #define SIO2MAN_HOOK_H
 
-int sio2man_hook_init();
-void sio2man_hook_deinit();
+#ifndef SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER
+#define SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER 1
+#endif
+
+extern int sio2man_hook_init();
+extern void sio2man_hook_deinit();
 
 // Lock all communication to SIO2MAN
 // this is needed for drivers that communicate directly to sio2, like mx4sio.
 // Do NOT lock for long duration, only for single (high speed) transfers
-void sio2man_hook_sio2_lock();
-void sio2man_hook_sio2_unlock();
-
-// SIO2MAN's intr handler
-extern int (*sio2man_intr_handler_ptr)(void *arg);
-extern void *sio2man_intr_arg_ptr;
-
-// Temporary replacement intr handler
-extern int (*mmce_sio2_intr_handler_ptr)(void *arg);
-extern void *mmce_sio2_intr_arg_ptr;
-
-extern intrman_internals_t *mmce_sio2_intrman_internals_ptr;
+extern void sio2man_hook_sio2_lock();
+extern void sio2man_hook_sio2_unlock();
+#if SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER
+extern void sio2man_hook_sio2_set_intr_handler(int (*handler)(void *userdata), void *userdata);
+#endif
 
 #endif

--- a/mmceman/src/ioplib.c
+++ b/mmceman/src/ioplib.c
@@ -1,24 +1,26 @@
-
 /*
 # _____     ___ ____     ___ ____
 #  ____|   |    ____|   |        | |____|
 # |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
 #-----------------------------------------------------------------------
-# Copyright 2001-2009, ps2dev - http://www.ps2dev.org
+# Copyright ps2dev - http://www.ps2dev.org
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
 #
 # taken from MX4SIO driver for simplicity.
 # all credits go to maximus32
 */
+
 #include "ioplib.h"
 #include <intrman.h>
 
-iop_library_t *ioplib_getByName(const char *name)
+int ioplib_iterateByName(const char *name, ioplib_libiterate_cb_t cb, void *userdata)
 {
     iop_library_t *libptr;
     int i;
+    int count;
 
+    count = 0;
     // Get first loaded library
     libptr = GetLoadcoreInternalData()->let_next;
     // Loop through all loaded libraries
@@ -29,15 +31,19 @@ iop_library_t *ioplib_getByName(const char *name)
                 break;
         }
 
-        // Return if match
-        if (i == 8)
-            return libptr;
+        // Call callback if match
+        if (i == 8) {
+            count += 1;
+            // Return early if requested
+            if (cb(libptr, userdata))
+                break;
+        }
 
         // Next library
         libptr = libptr->prev;
     }
 
-    return NULL;
+    return count;
 }
 
 unsigned int ioplib_getTableSize(iop_library_t *lib)
@@ -58,24 +64,25 @@ unsigned int ioplib_getTableSize(iop_library_t *lib)
     return size;
 }
 
-void *ioplib_hookExportEntry(iop_library_t *lib, unsigned int entry, void *func)
+void *ioplib_hookSameExportEntries(iop_library_t *lib, unsigned int entry, void *func)
 {
-    if (entry < ioplib_getTableSize(lib)) {
-        int oldstate;
-        void **exp, *temp;
+    int table_size;
+    int oldstate;
+    void *oldfunc;
+    unsigned int i;
 
-        exp = &lib->exports[entry];
+    table_size = ioplib_getTableSize(lib);
+    if (entry >= table_size)
+        return NULL;
 
-        CpuSuspendIntr(&oldstate);
-        temp = *exp;
-        *exp = func;
-        func = temp;
-        CpuResumeIntr(oldstate);
+    CpuSuspendIntr(&oldstate);
+    oldfunc = lib->exports[entry];
+    for (i = 0; i < table_size; i += 1)
+        if (lib->exports[i] == oldfunc)
+            lib->exports[i] = func;
+    CpuResumeIntr(oldstate);
 
-        return func;
-    }
-
-    return NULL;
+    return oldfunc;
 }
 
 void ioplib_relinkExports(iop_library_t *lib)

--- a/mmceman/src/mmce_sio2.c
+++ b/mmceman/src/mmce_sio2.c
@@ -26,13 +26,9 @@ static u32 mmce_sio2_port_ctrl2;
 static u32 sio2_save_ctrl;
 static int event_flag = -1;
 
-//SIO2MAN's intr handler
-int (*sio2man_intr_handler_ptr)(void *arg);
-void *sio2man_intr_arg_ptr;
-
 //Replacement intr handler
-int (*mmce_sio2_intr_handler_ptr)(void *arg) = NULL;
-void *mmce_sio2_intr_arg_ptr = NULL;
+static int (*mmce_sio2_intr_handler_ptr)(void *arg);
+static void *mmce_sio2_intr_arg_ptr;
 
 iop_sys_clock_t timeout_200ms;
 iop_sys_clock_t timeout_1s;
@@ -131,18 +127,13 @@ void mmce_sio2_deinit()
 
 void mmce_sio2_lock()
 {
-    int state;
-
     //Lock sio2man driver so we can use it exclusively
     sio2man_hook_sio2_lock();
 
     sio2_save_ctrl = inl_sio2_ctrl_get();
 
     //Swap SIO2MAN's intr handler with ours
-    CpuSuspendIntr(&state);
-    mmce_sio2_intrman_internals_ptr->interrupt_handler_table[17].handler = mmce_sio2_intr_handler_ptr; 
-    mmce_sio2_intrman_internals_ptr->interrupt_handler_table[17].userdata = mmce_sio2_intr_arg_ptr;
-    CpuResumeIntr(state);
+    sio2man_hook_sio2_set_intr_handler(mmce_sio2_intr_handler_ptr, mmce_sio2_intr_arg_ptr);
 
     //Copy port ctrl settings to SIO2 registers
     inl_sio2_portN_ctrl1_set(mmce_port, mmce_sio2_port_ctrl1);
@@ -151,13 +142,8 @@ void mmce_sio2_lock()
 
 void mmce_sio2_unlock()
 {
-    int state;
-
     //Swap our intr handler with SIO2MAN's intr handler
-    CpuSuspendIntr(&state);
-    mmce_sio2_intrman_internals_ptr->interrupt_handler_table[17].handler = sio2man_intr_handler_ptr; 
-    mmce_sio2_intrman_internals_ptr->interrupt_handler_table[17].userdata = sio2man_intr_arg_ptr;
-    CpuResumeIntr(state);
+    sio2man_hook_sio2_set_intr_handler(NULL, NULL);
 
     //Restore ctrl state, and reset STATE + FIFOS
     inl_sio2_ctrl_set(sio2_save_ctrl | 0xc);

--- a/mmceman/src/mmcedrv.c
+++ b/mmceman/src/mmcedrv.c
@@ -3,7 +3,6 @@
 #include <string.h>
 #include <sysclib.h>
 
-#include "ioplib.h"
 #include "irx_imports.h"
 
 #include "mmce_cmds.h"
@@ -370,7 +369,7 @@ void mmcedrv_config_set(int setting, int value)
     }
 }
 
-int __start(int argc, char *argv[])
+int __start(int argc, char *argv[], void *startaddr, ModuleInfo_t *mi)
 {
     int rv;
 
@@ -389,19 +388,14 @@ int __start(int argc, char *argv[])
         return MODULE_NO_RESIDENT_END;
     }
 
-    iop_library_t * lib_modload = ioplib_getByName("modload");
-    if (lib_modload != NULL) {
-        DPRINTF("modload 0x%x detected\n", lib_modload->version);
-        if (lib_modload->version > 0x102) //IOP is running a MODLOAD version which supports unloading IRX Modules
-            return MODULE_REMOVABLE_END; // and we do support getting unloaded...
-    } else {
-        DPRINTF("modload not detected! this is serious!\n");
-    }
-
+    // If modload has certain flags set indicating new version,
+    // set the unloadable flag
+    if (mi && ((mi->newflags & 2) != 0))
+        mi->newflags |= 0x10;
     return MODULE_RESIDENT_END;
 }
 
-int __stop(int argc, char *argv[])
+int __stop(int argc, char *argv[], void *startaddr, ModuleInfo_t *mi)
 {
     DPRINTF("Unloading module\n");
     
@@ -410,10 +404,10 @@ int __stop(int argc, char *argv[])
     return MODULE_NO_RESIDENT_END;
 }
 
-int _start(int argc, char *argv[])
+int _start(int argc, char *argv[], void *startaddr, ModuleInfo_t *mi)
 {
     if (argc >= 0) 
-        return __start(argc, argv);
+        return __start(argc, argv, startaddr, mi);
     else
-        return __stop(-argc, argv);
+        return __stop(-argc, argv, startaddr, mi);
 }

--- a/mmceman/src/mmceigr.c
+++ b/mmceman/src/mmceigr.c
@@ -2,7 +2,6 @@
 #include <sysclib.h>
 #include <tamtypes.h>
 
-#include "ioplib.h"
 #include "mmce_cmds.h"
 #include "sio2regs.h"
 #include "irx_imports.h"

--- a/mmceman/src/mmceman.c
+++ b/mmceman/src/mmceman.c
@@ -3,7 +3,6 @@
 #include <string.h>
 #include <sysclib.h>
 
-#include "ioplib.h"
 #include "irx_imports.h"
 
 #include "sio2man_hook.h"
@@ -54,7 +53,7 @@ static void mmce_init(int port)
     }
 }
 
-int __start(int argc, char *argv[])
+int __start(int argc, char *argv[], void *startaddr, ModuleInfo_t *mi)
 {
     int rv;
 
@@ -74,19 +73,14 @@ int __start(int argc, char *argv[])
     //Attach filesystem to iomanX
     mmce_fs_register();
 
-    iop_library_t * lib_modload = ioplib_getByName("modload");
-    if (lib_modload != NULL) {
-        DPRINTF("modload 0x%x detected\n", lib_modload->version);
-        if (lib_modload->version > 0x102) //IOP is running a MODLOAD version which supports unloading IRX Modules
-            return MODULE_REMOVABLE_END; // and we do support getting unloaded...
-    } else {
-        DPRINTF("modload not detected! this is serious!\n");
-    }
-
+    // If modload has certain flags set indicating new version,
+    // set the unloadable flag
+    if (mi && ((mi->newflags & 2) != 0))
+        mi->newflags |= 0x10;
     return MODULE_RESIDENT_END;
 }
 
-int __stop(int argc, char *argv[])
+int __stop(int argc, char *argv[], void *startaddr, ModuleInfo_t *mi)
 {
     DPRINTF("Unloading module\n");
     
@@ -96,10 +90,10 @@ int __stop(int argc, char *argv[])
     return MODULE_NO_RESIDENT_END;
 }
 
-int _start(int argc, char *argv[])
+int _start(int argc, char *argv[], void *startaddr, ModuleInfo_t *mi)
 {
     if (argc >= 0) 
-        return __start(argc, argv);
+        return __start(argc, argv, startaddr, mi);
     else
-        return __stop(-argc, argv);
+        return __stop(-argc, argv, startaddr, mi);
 }

--- a/mmceman/src/sio2man_hook.c
+++ b/mmceman/src/sio2man_hook.c
@@ -1,250 +1,260 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+# taken from MX4SIO driver for simplicity.
+# all credits go to maximus32
+*/
+
 #include <stdio.h>
 #include <string.h>
 #include <thsemap.h>
-#include <thbase.h>
+#include <intrman.h>
 
 #include "ioplib.h"
-#include "intrman.h"
 #include "sio2man.h"
 #include "sio2man_hook.h"
 
 // #define DEBUG  //comment out this line when not debugging
 #include "module_debug.h"
 
-static int lock_sema      = -1;
-static int lock_sema2     = -1;
-static u16 hooked_version = 0;
-
-intrman_internals_t *mmce_sio2_intrman_internals_ptr = NULL;
+#define PORT_NR 3
+#ifndef M_DEBUG
+#define M_DEBUG DPRINTF
+#endif
 
 // sio2man function typedefs
 typedef void (*psio2_transfer_init)(void);
 typedef int (*psio2_transfer)(sio2_transfer_data_t *td);
 typedef void (*psio2_transfer_reset)(void);
 
-// Original sio2man function pointers
-psio2_transfer_init _23_psio2_pad_transfer_init;
-psio2_transfer_init _24_psio2_mc_transfer_init;
-psio2_transfer_init _46_psio2_pad_transfer_init;
-psio2_transfer_init _47_psio2_mc_transfer_init;
-psio2_transfer_init _48_psio2_mtap_transfer_init;
-psio2_transfer_init _49_psio2_rm_transfer_init;
-psio2_transfer_init _50_psio2_unk_transfer_init;
-psio2_transfer _25_psio2_transfer;
-psio2_transfer _51_psio2_transfer;
-psio2_transfer_reset _26_psio2_transfer_reset;
-psio2_transfer_reset _52_psio2_transfer_reset;
-
-// Generic sio2man init function
-static void _sio2_transfer_init(psio2_transfer_init init_func)
+struct sio2man_hook_data
 {
-    //DPRINTF("%s\n", __FUNCTION__);
-    WaitSema(lock_sema);
-    init_func();
-}
+    iop_library_t *m_lib;
+    // Original sio2man function pointers
+    psio2_transfer_init m_23_psio2_pad_transfer_init;
+#ifdef PORT_NR
+    psio2_transfer m_25_psio2_transfer;
+#endif
+    psio2_transfer_reset m_26_psio2_transfer_reset;
+};
 
+static struct sio2man_hook_data g_hook_data[2];
+static iop_library_t *g_loadcore_lib;
+#if SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER
+static iop_library_t *g_intrman_lib;
+static int (*g_sio2man_intr_handler_ptr)(void *arg);
+static void *g_sio2man_intr_arg_ptr;
+#endif
+
+#ifdef PORT_NR
+static sio2_transfer_data_t g_null_td;
 // Generic sio2man transfer function
 static int _sio2_transfer(psio2_transfer transfer_func, sio2_transfer_data_t *td)
 {
-    int rv;
- 
-    //DPRINTF("%s\n", __FUNCTION__);
+    unsigned int i;
 
-    WaitSema(lock_sema2);
-    rv = transfer_func(td);
-    SignalSema(lock_sema2);
+    //M_DEBUG("%s\n", __FUNCTION__);
 
-    return rv;
-}
+    // Do not allow transfers to/from our used port
+    for (i = 0; i < (sizeof(td->regdata)/sizeof(td->regdata[0])); i++) {
+        // Last transfer, we're ok.
+        if (td->regdata[i] == 0)
+            break;
 
-// Generic sio2man transfer_reset function
-static void _sio2_transfer_reset(psio2_transfer_reset reset_func)
-{
-    //DPRINTF("%s\n", __FUNCTION__);
+        // Wrong port; behave as a no-op.
+        // This will allow the transfer reset behavior for old library to work.
+        if ((td->regdata[i] & 3) == PORT_NR)
+            return transfer_func(&g_null_td);
+    }
 
-    reset_func();
-    SignalSema(lock_sema);
+    return transfer_func(td);
 }
 
 // Hooked sio2man functions
-static void _23_sio2_pad_transfer_init() { _sio2_transfer_init(_23_psio2_pad_transfer_init); }
-static void _24_sio2_mc_transfer_init() { _sio2_transfer_init(_24_psio2_mc_transfer_init); }
-static void _46_sio2_pad_transfer_init() { _sio2_transfer_init(_46_psio2_pad_transfer_init); }
-static void _47_sio2_mc_transfer_init() { _sio2_transfer_init(_47_psio2_mc_transfer_init); }
-static void _48_sio2_mtap_transfer_init() { _sio2_transfer_init(_48_psio2_mtap_transfer_init); }
-static void _49_sio2_rm_transfer_init() { _sio2_transfer_init(_49_psio2_rm_transfer_init); }
-static void _50_sio2_unk_transfer_init() { _sio2_transfer_init(_50_psio2_unk_transfer_init); }
-static void _26_sio2_transfer_reset() { _sio2_transfer_reset(_26_psio2_transfer_reset); }
-static void _52_sio2_transfer_reset() { _sio2_transfer_reset(_52_psio2_transfer_reset); }
-static int  _25_sio2_transfer(sio2_transfer_data_t *td) { return _sio2_transfer(_25_psio2_transfer, td); }
-static int  _51_sio2_transfer(sio2_transfer_data_t *td) { return _sio2_transfer(_51_psio2_transfer, td); }
+static int _1_25_sio2_transfer(sio2_transfer_data_t *td) { return _sio2_transfer(g_hook_data[0].m_25_psio2_transfer, td); }
+static int _2_25_sio2_transfer(sio2_transfer_data_t *td) { return _sio2_transfer(g_hook_data[1].m_25_psio2_transfer, td); }
+#endif
 
-static void _sio2man_unhook(iop_library_t *lib)
-{
-    if (hooked_version == 0) {
-        DPRINTF("Warning: trying to unhook sio2man while not hooked\n");
-        return;
-    }
-
-    ioplib_hookExportEntry(lib, 23, _23_psio2_pad_transfer_init);
-    ioplib_hookExportEntry(lib, 24, _24_psio2_mc_transfer_init);
-    ioplib_hookExportEntry(lib, 25, _25_psio2_transfer);
-    ioplib_hookExportEntry(lib, 26, _26_psio2_transfer_reset);
-    ioplib_hookExportEntry(lib, 46, _46_psio2_pad_transfer_init);
-    ioplib_hookExportEntry(lib, 47, _47_psio2_mc_transfer_init);
-    ioplib_hookExportEntry(lib, 48, _48_psio2_mtap_transfer_init);
-
-    if ((hooked_version >= IRX_VER(1, 2)) && (hooked_version < IRX_VER(2, 0))) {
-        // Only for the newer rom0:XSIO2MAN
-        // Assume all v1.x libraries to use this interface (reset at 50)
-        ioplib_hookExportEntry(lib, 49, _51_psio2_transfer);
-        ioplib_hookExportEntry(lib, 50, _52_psio2_transfer_reset);
-    } else /*if (hooked_version >= IRX_VER(2, 3))*/ {
-        // Only for the newer rom1:SIO2MAN
-        // Assume all v2.x libraries to use this interface (reset at 52)
-        ioplib_hookExportEntry(lib, 49, _49_psio2_rm_transfer_init);
-        ioplib_hookExportEntry(lib, 50, _50_psio2_unk_transfer_init);
-        ioplib_hookExportEntry(lib, 51, _51_psio2_transfer);
-        ioplib_hookExportEntry(lib, 52, _52_psio2_transfer_reset);
-    }
-
-    hooked_version = 0;
-}
+static void unhook_loadcore(void);
+#if SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER
+static void unhook_intrman(void);
+#endif
 
 static void _sio2man_hook(iop_library_t *lib)
 {
-    if (hooked_version != 0) {
-        DPRINTF("Warning: trying to hook sio2man version 0x%x\n", lib->version);
-        DPRINTF("         while version 0x%x already hooked\n", hooked_version);
-        return;
-    }
+    int state;
 
-    // Only the newer sio2man libraries (with reset functions) are supported
-    if (lib->version > IRX_VER(1, 1)) {
-        DPRINTF("Installing sio2man hooks for version 0x%x\n", lib->version);
+    // Disable interrupts to prevent race conditions with MC/PAD libraries
+    CpuSuspendIntr(&state);
+    // Only the newest sio2man libraries (using one semaphore for locks for all devices) are supported
+    switch (lib->version)
+    {
+        case IRX_VER(1, 2):
+        case IRX_VER(2, 7):
+        {
+            int major_version;
 
-        _23_psio2_pad_transfer_init  = ioplib_hookExportEntry(lib, 23, _23_sio2_pad_transfer_init);
-        // Lock sio2 to prevent race conditions with MC/PAD libraries
-        _23_psio2_pad_transfer_init();
+            M_DEBUG("Installing sio2man hooks for version 0x%x\n", lib->version);
 
-        _24_psio2_mc_transfer_init   = ioplib_hookExportEntry(lib, 24, _24_sio2_mc_transfer_init);
-        _25_psio2_transfer           = ioplib_hookExportEntry(lib, 25, _25_sio2_transfer);
-        _26_psio2_transfer_reset     = ioplib_hookExportEntry(lib, 26, _26_sio2_transfer_reset);
-        _46_psio2_pad_transfer_init  = ioplib_hookExportEntry(lib, 46, _46_sio2_pad_transfer_init);
-        _47_psio2_mc_transfer_init   = ioplib_hookExportEntry(lib, 47, _47_sio2_mc_transfer_init);
-        _48_psio2_mtap_transfer_init = ioplib_hookExportEntry(lib, 48, _48_sio2_mtap_transfer_init);
-
-        if ((lib->version >= IRX_VER(1, 2)) && (lib->version < IRX_VER(2, 0))) {
-            // Only for the newer rom0:XSIO2MAN
-            // Assume all v1.x libraries to use this interface (reset at 50)
-            _51_psio2_transfer       = ioplib_hookExportEntry(lib, 49, _51_sio2_transfer);
-            _52_psio2_transfer_reset = ioplib_hookExportEntry(lib, 50, _52_sio2_transfer_reset);
-        } else /*if (lib->version >= IRX_VER(2, 3))*/ {
-            // Only for the newer rom1:SIO2MAN
-            // Assume all v2.x libraries to use this interface (reset at 52)
-            _49_psio2_rm_transfer_init  = ioplib_hookExportEntry(lib, 49, _49_sio2_rm_transfer_init);
-            _50_psio2_unk_transfer_init = ioplib_hookExportEntry(lib, 50, _50_sio2_unk_transfer_init);
-            _51_psio2_transfer          = ioplib_hookExportEntry(lib, 51, _51_sio2_transfer);
-            _52_psio2_transfer_reset    = ioplib_hookExportEntry(lib, 52, _52_sio2_transfer_reset);
+            major_version = ((lib->version >> 8) & 0xFF);
+            if (g_hook_data[major_version - 1].m_lib) {
+                M_DEBUG("Warning: trying to hook sio2man version 0x%x\n", lib->version);
+                M_DEBUG("         while version 0x%x already hooked\n", g_hook_data[major_version - 1].m_lib->version);
+            }
+            g_hook_data[major_version - 1].m_lib = lib;
+            g_hook_data[major_version - 1].m_23_psio2_pad_transfer_init  = lib->exports[23];
+#ifdef PORT_NR
+            g_hook_data[major_version - 1].m_25_psio2_transfer           = ioplib_hookSameExportEntries(lib, 25, (major_version == 1) ? &_1_25_sio2_transfer : &_2_25_sio2_transfer);
+#endif
+            g_hook_data[major_version - 1].m_26_psio2_transfer_reset     = lib->exports[26];
+#ifdef PORT_NR
+            ioplib_relinkExports(lib);
+#endif
+            break;
         }
-
-        // Unlock sio2
-        _26_psio2_transfer_reset();
-
-        hooked_version = lib->version;
-    } else {
-        DPRINTF("ERROR: sio2man version 0x%x not supported\n", lib->version);
+        default:
+        {
+            M_DEBUG("ERROR: sio2man version 0x%x not supported\n", lib->version);
+            break;
+        }
     }
+    if (g_hook_data[0].m_lib && g_hook_data[1].m_lib)
+        unhook_loadcore();
+    CpuResumeIntr(state);
 }
 
+#if SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER
 // intrman hook
-static int hooked = 0;
-int (*pRegisterIntrHandler)(int irq, int mode, int (*handler)(void *), void *arg);
+static int (*pRegisterIntrHandler)(int irq, int mode, int (*handler)(void *), void *arg);
 static int hookRegisterIntrHandler(int irq, int mode, int (*handler)(void *), void *arg)
 {
-    DPRINTF("RegisterIntrHandler irq: %i, handler @ 0x%p\n", irq, handler);
+    int ret;
+    M_DEBUG("RegisterIntrHandler irq: %i, handler @ 0x%p\n", irq, handler);
 
+    ret = pRegisterIntrHandler(irq, mode, handler, arg);
+    // If handler already exists or other error, then do not save handler
+    if (ret)
+        return ret;
     // SIO2 interrupt
-    if (irq == 17 && hooked == 0) {
-        // TODO: Possibly remove hook after SIO2MAN intr ptr is obtained
-        if (handler != mmce_sio2_intr_handler_ptr) {
-            sio2man_intr_handler_ptr = handler;
-            sio2man_intr_arg_ptr = arg;
-            hooked = 1;
-            
-            DPRINTF("Got SIO2MAN intr handler @ 0x%p, arg @ 0x%p\n", handler, arg);
-        }
+    if (irq == IOP_IRQ_SIO2 && !g_sio2man_intr_handler_ptr) {
+        g_sio2man_intr_handler_ptr = handler;
+        g_sio2man_intr_arg_ptr = arg;
+        M_DEBUG("Got SIO2MAN intr handler @ 0x%p, arg @ 0x%p\n", handler, arg);
+        unhook_intrman();
     }
-
-    return pRegisterIntrHandler(irq, mode, handler, arg);
+    return ret;
 }
+#endif
 
 // loadcore hook
-int (*pRegisterLibraryEntries)(iop_library_t *lib);
+static int (*pRegisterLibraryEntries)(iop_library_t *lib);
 static int hookRegisterLibraryEntries(iop_library_t *lib)
 {
-    //DPRINTF("RegisterLibraryEntries: %s 0x%x\n", lib->name, lib->version);
+    int ret;
+    M_DEBUG("RegisterLibraryEntries: %s 0x%x\n", lib->name, lib->version);
 
-    if (!strcmp(lib->name, "sio2man")) {
+    ret = pRegisterLibraryEntries(lib);
+    // If library already exists or other error, then do not hook
+    if (ret)
+        return ret;
+    if (!strcmp(lib->name, "sio2man"))
         _sio2man_hook(lib);
-    }
+    return ret;
+}
 
-    return pRegisterLibraryEntries(lib);
+static void unhook_loadcore(void)
+{
+    int state;
+
+    CpuSuspendIntr(&state);
+    if (g_loadcore_lib) {
+        if (pRegisterLibraryEntries)
+            ioplib_hookSameExportEntries(g_loadcore_lib, 6, pRegisterLibraryEntries);
+        g_loadcore_lib = NULL;
+    }
+    CpuResumeIntr(state);
+}
+
+#if SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER
+static void unhook_intrman(void)
+{
+    int state;
+
+    CpuSuspendIntr(&state);
+    if (g_intrman_lib) {
+        if (pRegisterIntrHandler)
+            ioplib_hookSameExportEntries(g_intrman_lib, 4, pRegisterIntrHandler);
+        g_intrman_lib = NULL;
+    }
+    CpuResumeIntr(state);
+}
+#endif
+
+static int generic_hook_iterate_cb(iop_library_t *lib, void *userdata)
+{
+    (void)userdata;
+    if (userdata && !*(iop_library_t **)userdata)
+        *(iop_library_t **)userdata = lib;
+    return 1;
+}
+
+static int sio2man_hook_iterate_cb(iop_library_t *lib, void *userdata)
+{
+    (void)userdata;
+    switch ((lib->version >> 8) & 0xFF)
+    {
+        case 1:
+        case 2:
+        {
+            _sio2man_hook(lib);
+            return (g_hook_data[0].m_lib && g_hook_data[1].m_lib) ? 1 : 0;
+        }
+        default:
+            return 1;
+    }
 }
 
 int sio2man_hook_init()
 {
-    iop_sema_t sema;
-    iop_library_t *lib;
+    M_DEBUG("%s\n", __FUNCTION__);
 
-    //DPRINTF("%s\n", __FUNCTION__);
+#if SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER
+    {
+        intrman_internals_t *intrman_internals;
 
-    // Get ptr to intrmans internals
-    mmce_sio2_intrman_internals_ptr = GetIntrmanInternalData();
-    if (mmce_sio2_intrman_internals_ptr == NULL) {
-        DPRINTF("Failed to get intrman internals ptr\n");
-        return -1;
+        intrman_internals = GetIntrmanInternalData();
+        // Get sio2man intr handler
+        g_sio2man_intr_handler_ptr = intrman_internals->interrupt_handler_table[IOP_IRQ_SIO2].handler;
+        g_sio2man_intr_arg_ptr = intrman_internals->interrupt_handler_table[IOP_IRQ_SIO2].userdata;
     }
-
-    // Create semaphore for locking sio2man exclusively
-    sema.attr    = 1;
-    sema.initial = 1;
-    sema.max     = 1;
-    sema.option  = 0;
-    lock_sema    = CreateSema(&sema);
-    lock_sema2   = CreateSema(&sema);
+#endif
 
     // Hook into 'sio2man' now if it's already loaded
-    lib = ioplib_getByName("sio2man");
-    if (lib != NULL) {
-        // Get sio2man intr handler
-        sio2man_intr_handler_ptr = mmce_sio2_intrman_internals_ptr->interrupt_handler_table[17].handler; //TODO: mode set in lowest 2 bits
-        sio2man_intr_arg_ptr = mmce_sio2_intrman_internals_ptr->interrupt_handler_table[17].userdata;
-        DPRINTF("Got SIO2MAN intr handler @ 0x%p, arg @ 0x%p\n", sio2man_intr_handler_ptr, sio2man_intr_arg_ptr);
-    
-        // Hook into sio2man
-        _sio2man_hook(lib);
-        ioplib_relinkExports(lib);
-    
-    // 'sio2man' is not loaded yet
-    } else {
+    if (!ioplib_iterateByName("sio2man", &sio2man_hook_iterate_cb, NULL)) {
         // Hook into 'loadcore' so we know when sio2man is loaded in the future
-        lib = ioplib_getByName("loadcore");
-        if (lib == NULL) {
-            DeleteSema(lock_sema);
-            DeleteSema(lock_sema2);
+        ioplib_iterateByName("loadcore", &generic_hook_iterate_cb, &g_loadcore_lib);
+#if SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER
+        // Hook into 'intrman' so we can get its handlers when they are registered
+        ioplib_iterateByName("intrman", &generic_hook_iterate_cb, &g_intrman_lib);
+#endif
+        if (!g_loadcore_lib)
             return -1;
-        }
-        pRegisterLibraryEntries = ioplib_hookExportEntry(lib, 6, hookRegisterLibraryEntries);
-
-        // Hook into intrman to get ptr to sio2man's intr handler in future
-        lib = ioplib_getByName("intrman");
-        if (lib == NULL) {
-            DeleteSema(lock_sema);
-            DeleteSema(lock_sema2);
+#if SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER
+        if (!g_intrman_lib)
             return -1;
-        }
-        pRegisterIntrHandler = ioplib_hookExportEntry(lib, 4, hookRegisterIntrHandler);
+#endif
+        pRegisterLibraryEntries = ioplib_hookSameExportEntries(g_loadcore_lib, 6, hookRegisterLibraryEntries);
+        ioplib_relinkExports(g_loadcore_lib);
+#if SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER
+        pRegisterIntrHandler = ioplib_hookSameExportEntries(g_intrman_lib, 4, hookRegisterIntrHandler);
+        ioplib_relinkExports(g_intrman_lib);
+#endif
     }
 
     return 0;
@@ -252,44 +262,54 @@ int sio2man_hook_init()
 
 void sio2man_hook_deinit()
 {
-    iop_library_t *lib;
+    unsigned int i;
 
-    //DPRINTF("%s\n", __FUNCTION__);
+    M_DEBUG("%s\n", __FUNCTION__);
 
     // Unhook 'sio2man'
-    lib = ioplib_getByName("sio2man");
-    if (lib != NULL) {
-        _sio2man_unhook(lib);
-        ioplib_relinkExports(lib);
+    for (i = 0; i < (sizeof(g_hook_data)/sizeof(g_hook_data[0])); i += 1) {
+        if (g_hook_data[i].m_lib) {
+#ifdef PORT_NR
+            if (g_hook_data[i].m_25_psio2_transfer) {
+                ioplib_hookSameExportEntries(g_hook_data[i].m_lib, 25, g_hook_data[i].m_25_psio2_transfer);
+                g_hook_data[i].m_25_psio2_transfer = NULL;
+            }
+            ioplib_relinkExports(g_hook_data[i].m_lib);
+#endif
+            g_hook_data[i].m_lib = NULL;
+        }
     }
 
-    // Unhook 'loadcore'
-    lib = ioplib_getByName("loadcore");
-    if (lib != NULL) {
-        ioplib_hookExportEntry(lib, 6, pRegisterLibraryEntries);
-    }
-
-    // Unhook 'intrman'
-    lib = ioplib_getByName("intrman");
-    if (lib != NULL) {
-        ioplib_hookExportEntry(lib, 4, pRegisterIntrHandler);
-    }
-
-    // Delete locking semaphore
-    DeleteSema(lock_sema);
-    DeleteSema(lock_sema2);
+    unhook_loadcore();
+#if SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER
+    unhook_intrman();
+#endif
 }
 
 void sio2man_hook_sio2_lock()
 {
     // Lock sio2man driver so we can use it exclusively
-    WaitSema(lock_sema);
-    WaitSema(lock_sema2);
+    if (g_hook_data[1].m_23_psio2_pad_transfer_init)
+        g_hook_data[1].m_23_psio2_pad_transfer_init();
 }
 
 void sio2man_hook_sio2_unlock()
 {
     // Unlock sio2man driver
-    SignalSema(lock_sema2);
-    SignalSema(lock_sema);
+    if (g_hook_data[1].m_26_psio2_transfer_reset)
+        g_hook_data[1].m_26_psio2_transfer_reset();
 }
+
+#if SIO2MAN_HOOK_SUPPORT_SET_INTR_HANDLER
+void sio2man_hook_sio2_set_intr_handler(int (*handler)(void *userdata), void *userdata)
+{
+    intrman_internals_t *intrman_internals;
+    int state;
+
+    intrman_internals = GetIntrmanInternalData();
+    CpuSuspendIntr(&state);
+    intrman_internals->interrupt_handler_table[IOP_IRQ_SIO2].handler = handler ? handler : g_sio2man_intr_handler_ptr;
+    intrman_internals->interrupt_handler_table[IOP_IRQ_SIO2].userdata = handler ? userdata : g_sio2man_intr_arg_ptr;
+    CpuResumeIntr(state);    
+}
+#endif


### PR DESCRIPTION
**Untested** by myself (except module loading and padman/mcman functionality)  

Fixes needed when using newest revision variant of mcman and padman from ps2sdk.

Make hook simpler due to sio2man using a single semaphore  
Unhook intrman and loadcore when hooks no longer needed  
Add API for interrupt handler  
For loadcore and intrman hooks, only proceed when inner function succeeds

A major breaking change is that it now relies on the sio2man module from ps2sdk, which is smaller than the original SCE module and supports all known interfaces from 1.1 to 2.7.